### PR TITLE
fix: sort VNDB name searches by searchrank

### DIFF
--- a/internal/utils/metadata/metadata_vndb.go
+++ b/internal/utils/metadata/metadata_vndb.go
@@ -33,10 +33,12 @@ func NewVNDBInfoGetterWithLanguage(language string) *VNDBInfoGetter {
 var _ Getter = (*VNDBInfoGetter)(nil)
 
 const vndbAPIURL = "https://api.vndb.org/kana/vn"
+const vndbSearchSort = "searchrank"
 
 type vndbRequest struct {
 	Filters []interface{} `json:"filters"`
 	Fields  string        `json:"fields"`
+	Sort    string        `json:"sort,omitempty"`
 }
 
 type vndbImage struct {
@@ -78,17 +80,18 @@ type vndbResponse struct {
 }
 
 func (v VNDBInfoGetter) FetchMetadata(id string, token string) (MetadataResult, error) {
-	return v.queryVNDB([]interface{}{"id", "=", id})
+	return v.queryVNDB([]interface{}{"id", "=", id}, "")
 }
 
 func (v VNDBInfoGetter) FetchMetadataByName(name string, token string) (MetadataResult, error) {
-	return v.queryVNDB([]interface{}{"search", "=", name})
+	return v.queryVNDB([]interface{}{"search", "=", name}, vndbSearchSort)
 }
 
-func (v VNDBInfoGetter) queryVNDB(filters []interface{}) (MetadataResult, error) {
+func (v VNDBInfoGetter) queryVNDB(filters []interface{}, sort string) (MetadataResult, error) {
 	reqBody := vndbRequest{
 		Filters: filters,
 		Fields:  "id, title, titles.lang, titles.title, titles.latin, titles.official, titles.main, image.url, description, rating, released, developers.name, tags.name, tags.rating, tags.spoiler",
+		Sort:    sort,
 	}
 
 	jsonData, err := json.Marshal(reqBody)


### PR DESCRIPTION
>Accepted values for "sort": id, title, released, rating, votecount, searchrank. [参考](https://api.vndb.org/kana#post-vn)

只有指定 sort 为 `searchrank` 时才与 vndb 站点搜索的结果一致，如果不指定 sort，则会出现搜索部分游戏时，vndb 源准确度较差的情况

lunabox 内搜索 island：
<img width="993" height="741" alt="b5813963e9526f230331a15f2487385c" src="https://github.com/user-attachments/assets/664c7584-4483-4912-8a9a-a00572956b29" />
vndb 站点搜索 island：
<img width="465" height="381" alt="image" src="https://github.com/user-attachments/assets/c57202a5-6d6f-4a14-89bc-9ff9ffb6e397" />
