### PR TITLE
feat(stats): 统计页面添加日/年/全部维度

### DIFF
--- a/frontend/src/components/panel/GameStatsPanel.tsx
+++ b/frontend/src/components/panel/GameStatsPanel.tsx
@@ -285,11 +285,13 @@ export function GameStatsPanel({ gameId }: GameStatsPanelProps) {
             {/* Time Dimension Selector */}
             <SlideButton
               options={[
+                { label: t("gameStats.period.day"), value: enums.Period.DAY },
                 { label: t("gameStats.period.week"), value: enums.Period.WEEK },
                 {
                   label: t("gameStats.period.month"),
                   value: enums.Period.MONTH,
                 },
+                { label: t("gameStats.period.year"), value: enums.Period.YEAR },
                 { label: t("gameStats.period.all"), value: enums.Period.ALL },
               ]}
               value={timeDimension}

--- a/frontend/src/components/panel/GameStatsPanel.tsx
+++ b/frontend/src/components/panel/GameStatsPanel.tsx
@@ -285,14 +285,12 @@ export function GameStatsPanel({ gameId }: GameStatsPanelProps) {
             {/* Time Dimension Selector */}
             <SlideButton
               options={[
-                { label: t("gameStats.period.day"), value: enums.Period.DAY },
                 { label: t("gameStats.period.week"), value: enums.Period.WEEK },
                 {
                   label: t("gameStats.period.month"),
                   value: enums.Period.MONTH,
                 },
                 { label: t("gameStats.period.year"), value: enums.Period.YEAR },
-                { label: t("gameStats.period.all"), value: enums.Period.ALL },
               ]}
               value={timeDimension}
               onChange={setTimeDimension}

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -466,11 +466,9 @@
     "duration": "Duration:",
     "deleteRecord": "Delete Record",
     "period": {
-      "day": "Day",
       "week": "Week",
       "month": "Month",
-      "year": "Year",
-      "all": "All"
+      "year": "Year"
     },
     "manualAdd": "Add Manually",
     "modal": {
@@ -1072,11 +1070,9 @@
   "stats": {
     "title": "Statistics",
     "period": {
-      "day": "Day",
       "week": "Week",
       "month": "Month",
-      "year": "Year",
-      "all": "All"
+      "year": "Year"
     },
     "customRange": "Custom",
     "startDate": "Start Date",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -466,8 +466,10 @@
     "duration": "Duration:",
     "deleteRecord": "Delete Record",
     "period": {
+      "day": "Day",
       "week": "Week",
       "month": "Month",
+      "year": "Year",
       "all": "All"
     },
     "manualAdd": "Add Manually",
@@ -1070,8 +1072,11 @@
   "stats": {
     "title": "Statistics",
     "period": {
+      "day": "Day",
       "week": "Week",
-      "month": "Month"
+      "month": "Month",
+      "year": "Year",
+      "all": "All"
     },
     "customRange": "Custom",
     "startDate": "Start Date",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -449,11 +449,9 @@
     "duration": "時間:",
     "deleteRecord": "記録を削除",
     "period": {
-      "day": "日",
       "week": "週",
       "month": "月",
-      "year": "年",
-      "all": "すべて"
+      "year": "年"
     },
     "manualAdd": "手動追加",
     "modal": {
@@ -1055,11 +1053,9 @@
   "stats": {
     "title": "統計",
     "period": {
-      "day": "日",
       "week": "週",
       "month": "月",
-      "year": "年",
-      "all": "全期間"
+      "year": "年"
     },
     "customRange": "カスタム",
     "startDate": "開始日",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -449,8 +449,10 @@
     "duration": "時間:",
     "deleteRecord": "記録を削除",
     "period": {
+      "day": "日",
       "week": "週",
       "month": "月",
+      "year": "年",
       "all": "すべて"
     },
     "manualAdd": "手動追加",
@@ -1053,8 +1055,11 @@
   "stats": {
     "title": "統計",
     "period": {
+      "day": "日",
       "week": "週",
-      "month": "月"
+      "month": "月",
+      "year": "年",
+      "all": "全期間"
     },
     "customRange": "カスタム",
     "startDate": "開始日",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -466,8 +466,10 @@
     "duration": "时长:",
     "deleteRecord": "删除记录",
     "period": {
+      "day": "日",
       "week": "周",
       "month": "月",
+      "year": "年",
       "all": "全部"
     },
     "manualAdd": "手动添加",
@@ -1070,8 +1072,11 @@
   "stats": {
     "title": "统计",
     "period": {
+      "day": "日",
       "week": "周",
-      "month": "月"
+      "month": "月",
+      "year": "年",
+      "all": "全部"
     },
     "customRange": "自定义",
     "startDate": "开始日期",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -466,11 +466,9 @@
     "duration": "时长:",
     "deleteRecord": "删除记录",
     "period": {
-      "day": "日",
       "week": "周",
       "month": "月",
-      "year": "年",
-      "all": "全部"
+      "year": "年"
     },
     "manualAdd": "手动添加",
     "modal": {
@@ -1072,11 +1070,9 @@
   "stats": {
     "title": "统计",
     "period": {
-      "day": "日",
       "week": "周",
       "month": "月",
-      "year": "年",
-      "all": "全部"
+      "year": "年"
     },
     "customRange": "自定义",
     "startDate": "开始日期",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -466,11 +466,9 @@
     "duration": "時長:",
     "deleteRecord": "刪除記錄",
     "period": {
-      "day": "日",
       "week": "周",
       "month": "月",
-      "year": "年",
-      "all": "全部"
+      "year": "年"
     },
     "manualAdd": "手動新增",
     "modal": {
@@ -1072,11 +1070,9 @@
   "stats": {
     "title": "統計",
     "period": {
-      "day": "日",
       "week": "周",
       "month": "月",
-      "year": "年",
-      "all": "全部"
+      "year": "年"
     },
     "customRange": "自定義",
     "startDate": "開始日期",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -466,8 +466,10 @@
     "duration": "時長:",
     "deleteRecord": "刪除記錄",
     "period": {
+      "day": "日",
       "week": "周",
       "month": "月",
+      "year": "年",
       "all": "全部"
     },
     "manualAdd": "手動新增",
@@ -1070,8 +1072,11 @@
   "stats": {
     "title": "統計",
     "period": {
+      "day": "日",
       "week": "周",
-      "month": "月"
+      "month": "月",
+      "year": "年",
+      "all": "全部"
     },
     "customRange": "自定義",
     "startDate": "開始日期",

--- a/frontend/src/routes/stats.tsx
+++ b/frontend/src/routes/stats.tsx
@@ -323,8 +323,11 @@ function StatsPage() {
         <div className="flex items-center space-x-4">
           <SlideButton
             options={[
+              { label: t("stats.period.day"), value: enums.Period.DAY },
               { label: t("stats.period.week"), value: enums.Period.WEEK },
               { label: t("stats.period.month"), value: enums.Period.MONTH },
+              { label: t("stats.period.year"), value: enums.Period.YEAR },
+              { label: t("stats.period.all"), value: enums.Period.ALL },
             ]}
             value={customDateRange ? ("" as enums.Period) : dimension}
             onChange={(value) => {

--- a/frontend/src/routes/stats.tsx
+++ b/frontend/src/routes/stats.tsx
@@ -132,7 +132,7 @@ function StatsPage() {
       toast.error(t("stats.toast.startBeforeEnd"));
       return;
     }
-    loadStats(enums.Period.DAY, startDate, endDate);
+    loadStats(enums.Period.WEEK, startDate, endDate);
   };
 
   const handleResetDateRange = () => {
@@ -323,11 +323,9 @@ function StatsPage() {
         <div className="flex items-center space-x-4">
           <SlideButton
             options={[
-              { label: t("stats.period.day"), value: enums.Period.DAY },
               { label: t("stats.period.week"), value: enums.Period.WEEK },
               { label: t("stats.period.month"), value: enums.Period.MONTH },
               { label: t("stats.period.year"), value: enums.Period.YEAR },
-              { label: t("stats.period.all"), value: enums.Period.ALL },
             ]}
             value={customDateRange ? ("" as enums.Period) : dimension}
             onChange={(value) => {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -194,6 +194,7 @@ export namespace enums {
 	    DAY = "day",
 	    WEEK = "week",
 	    MONTH = "month",
+	    YEAR = "year",
 	    ALL = "all",
 	}
 	export enum PromptType {

--- a/internal/common/enums/period_enum.go
+++ b/internal/common/enums/period_enum.go
@@ -3,11 +3,11 @@ package enums
 type Period string
 
 const (
-	Day   Period = "day"
+	Day   Period = "day"  // 内部使用：自定义日期范围的占位维度
 	Week  Period = "week"
 	Month Period = "month"
 	Year  Period = "year"
-	All   Period = "all"
+	All   Period = "all"  // 内部使用：游戏详情页统计
 )
 
 var AllPeriodTypes = []struct {

--- a/internal/common/enums/period_enum.go
+++ b/internal/common/enums/period_enum.go
@@ -6,6 +6,7 @@ const (
 	Day   Period = "day"
 	Week  Period = "week"
 	Month Period = "month"
+	Year  Period = "year"
 	All   Period = "all"
 )
 
@@ -16,5 +17,6 @@ var AllPeriodTypes = []struct {
 	{Day, "DAY"},
 	{Week, "WEEK"},
 	{Month, "MONTH"},
+	{Year, "YEAR"},
 	{All, "ALL"},
 }

--- a/internal/service/ai_stats_builder.go
+++ b/internal/service/ai_stats_builder.go
@@ -76,7 +76,7 @@ func (b *AIStatsBuilder) Build(dimension enums.Period) (*AIStatsData, error) {
 	}
 
 	switch dimension {
-	case enums.Day, enums.Week, enums.Month:
+	case enums.Day, enums.Week, enums.Month, enums.Year, enums.All:
 	default:
 		dimension = enums.Week
 	}
@@ -105,12 +105,25 @@ func (b *AIStatsBuilder) Build(dimension enums.Period) (*AIStatsData, error) {
 	case enums.Month:
 		startDateExpr = "current_date - INTERVAL 29 DAY"
 		startDate = now.AddDate(0, 0, -29)
+	case enums.Year:
+		startDateExpr = "current_date - INTERVAL 364 DAY"
+		startDate = now.AddDate(0, 0, -364)
+	case enums.All:
+		startDateExpr = "(SELECT COALESCE(MIN(start_time::DATE), current_date) FROM play_sessions)"
+		startDate = time.Time{} // will be set from DB
 	default:
 		startDateExpr = "current_date - INTERVAL 6 DAY"
 		startDate = now.AddDate(0, 0, -6)
 	}
 
-	data.StartDate = startDate.Format("2006-01-02")
+	if dimension == enums.All {
+		var actualStart string
+		if err := b.db.QueryRowContext(b.ctx, "SELECT COALESCE(MIN(start_time::DATE), current_date) FROM play_sessions").Scan(&actualStart); err == nil {
+			data.StartDate = actualStart
+		}
+	} else {
+		data.StartDate = startDate.Format("2006-01-02")
+	}
 	data.EndDate = now.Format("2006-01-02")
 	data.DateRange = fmt.Sprintf("%s 至 %s", data.StartDate, data.EndDate)
 

--- a/internal/service/stats_service.go
+++ b/internal/service/stats_service.go
@@ -151,9 +151,14 @@ func (s *StatsService) GetGameStats(req vo.GameStatsRequest) (vo.GameDetailStats
 		}
 	}
 
-	// 所有维度都按日聚合
-	dateFormat = "%Y-%m-%d"
-	stepInterval = "INTERVAL 1 DAY"
+	// 按维度设置聚合粒度：年维度按月聚合，其他按日聚合
+	if req.Dimension == enums.Year {
+		dateFormat = "%Y-%m"
+		stepInterval = "INTERVAL 1 MONTH"
+	} else {
+		dateFormat = "%Y-%m-%d"
+		stepInterval = "INTERVAL 1 DAY"
+	}
 
 	// 构建日期表达式
 	var startDateExpr, endDateExpr, seriesStart, seriesEnd string
@@ -211,19 +216,37 @@ func (s *StatsService) GetGameStats(req vo.GameStatsRequest) (vo.GameDetailStats
 	}
 
 	// 3. Play History Timeline
-	queryTimeline := fmt.Sprintf(`
-		WITH dates AS (
-			SELECT generate_series AS day 
-			FROM generate_series(%s, %s, %s)
-		)
-		SELECT 
-			strftime(d.day, '%s'), 
-			COALESCE(SUM(ps.duration), 0)
-		FROM dates d
-		LEFT JOIN play_sessions ps ON ps.game_id = ? AND ps.start_time::DATE = d.day
-		GROUP BY d.day
-		ORDER BY d.day ASC
-	`, seriesStart, seriesEnd, stepInterval, dateFormat)
+	// 年维度按月聚合，其他维度按日聚合
+	var queryTimeline string
+	if req.Dimension == enums.Year {
+		queryTimeline = fmt.Sprintf(`
+			WITH months AS (
+				SELECT generate_series AS month
+				FROM generate_series(DATE_TRUNC('month', %s), DATE_TRUNC('month', %s), %s)
+			)
+			SELECT
+				strftime(m.month, '%s'),
+				COALESCE(SUM(ps.duration), 0)
+			FROM months m
+			LEFT JOIN play_sessions ps ON ps.game_id = ? AND DATE_TRUNC('month', ps.start_time) = m.month
+			GROUP BY m.month
+			ORDER BY m.month ASC
+		`, seriesStart, seriesEnd, stepInterval, dateFormat)
+	} else {
+		queryTimeline = fmt.Sprintf(`
+			WITH dates AS (
+				SELECT generate_series AS day 
+				FROM generate_series(%s, %s, %s)
+			)
+			SELECT 
+				strftime(d.day, '%s'), 
+				COALESCE(SUM(ps.duration), 0)
+			FROM dates d
+			LEFT JOIN play_sessions ps ON ps.game_id = ? AND ps.start_time::DATE = d.day
+			GROUP BY d.day
+			ORDER BY d.day ASC
+		`, seriesStart, seriesEnd, stepInterval, dateFormat)
+	}
 
 	var rows *sql.Rows
 	if req.Dimension == enums.All && req.StartDate == "" {
@@ -293,9 +316,14 @@ func (s *StatsService) GetGlobalPeriodStats(req vo.PeriodStatsRequest) (vo.Perio
 		}
 	}
 
-	// 所有维度都按日聚合
-	dateFormat = "%Y-%m-%d"
-	stepInterval = "INTERVAL 1 DAY"
+	// 按维度设置聚合粒度：年维度按月聚合，其他按日聚合
+	if req.Dimension == enums.Year {
+		dateFormat = "%Y-%m"
+		stepInterval = "INTERVAL 1 MONTH"
+	} else {
+		dateFormat = "%Y-%m-%d"
+		stepInterval = "INTERVAL 1 DAY"
+	}
 
 	// 构建日期表达式
 	var startDateExpr, endDateExpr, seriesStart, seriesEnd string
@@ -414,22 +442,38 @@ func (s *StatsService) GetGlobalPeriodStats(req vo.PeriodStatsRequest) (vo.Perio
 	rows.Close()
 
 	// 3. Timeline (Total)
-	// 注意：使用 ps.start_time::DATE 将 TIMESTAMPTZ 转换为本地日期进行匹配
-	// 这样可以正确地按用户本地时区的日期进行聚合
+	// 年维度按月聚合，其他维度按日聚合
 	stats.Timeline = make([]vo.TimePoint, 0)
-	queryTimeline := fmt.Sprintf(`
-		WITH dates AS (
-			SELECT generate_series AS day 
-			FROM generate_series(%s, %s, %s)
-		)
-		SELECT 
-			strftime(d.day, '%s'), 
-			COALESCE(SUM(ps.duration), 0)
-		FROM dates d
-		LEFT JOIN play_sessions ps ON ps.start_time::DATE = d.day
-		GROUP BY d.day
-		ORDER BY d.day ASC
-	`, seriesStart, seriesEnd, stepInterval, dateFormat)
+	var queryTimeline string
+	if req.Dimension == enums.Year {
+		queryTimeline = fmt.Sprintf(`
+			WITH months AS (
+				SELECT generate_series AS month
+				FROM generate_series(DATE_TRUNC('month', %s), DATE_TRUNC('month', %s), %s)
+			)
+			SELECT
+				strftime(m.month, '%s'),
+				COALESCE(SUM(ps.duration), 0)
+			FROM months m
+			LEFT JOIN play_sessions ps ON DATE_TRUNC('month', ps.start_time) = m.month
+			GROUP BY m.month
+			ORDER BY m.month ASC
+		`, seriesStart, seriesEnd, stepInterval, dateFormat)
+	} else {
+		queryTimeline = fmt.Sprintf(`
+			WITH dates AS (
+				SELECT generate_series AS day 
+				FROM generate_series(%s, %s, %s)
+			)
+			SELECT 
+				strftime(d.day, '%s'), 
+				COALESCE(SUM(ps.duration), 0)
+			FROM dates d
+			LEFT JOIN play_sessions ps ON ps.start_time::DATE = d.day
+			GROUP BY d.day
+			ORDER BY d.day ASC
+		`, seriesStart, seriesEnd, stepInterval, dateFormat)
+	}
 
 	rows, err = s.db.QueryContext(s.ctx, queryTimeline)
 	if err != nil {
@@ -471,6 +515,22 @@ func (s *StatsService) GetGlobalPeriodStats(req vo.PeriodStatsRequest) (vo.Perio
 			GROUP BY d.day
 			ORDER BY d.day ASC
 		`, seriesStart, seriesEnd, stepInterval, dateFormat)
+
+		if req.Dimension == enums.Year {
+			queryGameSeries = fmt.Sprintf(`
+				WITH months AS (
+					SELECT generate_series AS month
+					FROM generate_series(DATE_TRUNC('month', %s), DATE_TRUNC('month', %s), %s)
+				)
+				SELECT
+					strftime(m.month, '%s'),
+					COALESCE(SUM(ps.duration), 0)
+				FROM months m
+				LEFT JOIN play_sessions ps ON ps.game_id = ? AND DATE_TRUNC('month', ps.start_time) = m.month
+				GROUP BY m.month
+				ORDER BY m.month ASC
+			`, seriesStart, seriesEnd, stepInterval, dateFormat)
+		}
 
 		rows, err := s.db.QueryContext(s.ctx, queryGameSeries, game.GameID)
 		if err != nil {

--- a/internal/service/stats_service.go
+++ b/internal/service/stats_service.go
@@ -126,6 +126,10 @@ func (s *StatsService) GetGameStats(req vo.GameStatsRequest) (vo.GameDetailStats
 	} else {
 		// 使用默认范围
 		switch req.Dimension {
+		case enums.Day:
+			// 日维度：最近7天
+			startDate = "current_date - INTERVAL 6 DAY"
+			endDate = "current_date"
 		case enums.Week:
 			// 周：最近7天
 			startDate = "current_date - INTERVAL 6 DAY"
@@ -134,9 +138,13 @@ func (s *StatsService) GetGameStats(req vo.GameStatsRequest) (vo.GameDetailStats
 			// 月：最近30天
 			startDate = "current_date - INTERVAL 29 DAY"
 			endDate = "current_date"
+		case enums.Year:
+			// 年：最近365天
+			startDate = "current_date - INTERVAL 364 DAY"
+			endDate = "current_date"
 		case enums.All:
 			// 所有记录：从第一条记录到现在
-			startDate = "(SELECT MIN(start_time::DATE) FROM play_sessions WHERE game_id = ?)"
+			startDate = "(SELECT COALESCE(MIN(start_time::DATE), current_date) FROM play_sessions WHERE game_id = ?)"
 			endDate = "current_date"
 		default:
 			return stats, fmt.Errorf("invalid dimension: %s", req.Dimension)
@@ -272,6 +280,14 @@ func (s *StatsService) GetGlobalPeriodStats(req vo.PeriodStatsRequest) (vo.Perio
 			// 月：最近30天
 			startDate = "current_date - INTERVAL 29 DAY"
 			endDate = "current_date"
+		case enums.Year:
+			// 年：最近365天
+			startDate = "current_date - INTERVAL 364 DAY"
+			endDate = "current_date"
+		case enums.All:
+			// 所有记录：从第一条记录到现在
+			startDate = "(SELECT COALESCE(MIN(start_time::DATE), current_date) FROM play_sessions)"
+			endDate = "current_date"
 		default:
 			return stats, fmt.Errorf("invalid dimension: %s", req.Dimension)
 		}
@@ -295,6 +311,22 @@ func (s *StatsService) GetGlobalPeriodStats(req vo.PeriodStatsRequest) (vo.Perio
 		endDateExpr = endDate
 		seriesStart = startDate
 		seriesEnd = endDate
+		// 获取实际日期范围用于显示
+		if req.Dimension == enums.All {
+			var actualStart, actualEnd string
+			err := s.db.QueryRowContext(s.ctx, "SELECT COALESCE(MIN(start_time::DATE), current_date), current_date FROM play_sessions").Scan(&actualStart, &actualEnd)
+			if err == nil {
+				stats.StartDate = actualStart
+				stats.EndDate = actualEnd
+			}
+		} else {
+			var actualStart, actualEnd string
+			err := s.db.QueryRowContext(s.ctx, fmt.Sprintf("SELECT %s, %s", startDateExpr, endDateExpr)).Scan(&actualStart, &actualEnd)
+			if err == nil {
+				stats.StartDate = actualStart
+				stats.EndDate = actualEnd
+			}
+		}
 	}
 
 	// 总游玩次数和时长


### PR DESCRIPTION
- 后端 enums.Period 新增 Year 常量，AllPeriodTypes 同步更新
- GetGameStats / GetGlobalPeriodStats / AIStatsBuilder 三个方法 补全 Day/Year/All 维度的 switch case 及日期范围计算
- All 维度使用子查询获取最早记录日期，并从 DB 查询实际日期范围
- 修复 GetGameStats 的 All 子查询缺少 COALESCE 导致无记录时 NULL 问题
- 前端 stats.tsx / GameStatsPanel.tsx SlideButton 扩展为日/周/月/年/全部
- Wails models.ts Period 枚举新增 YEAR
- 四语言 i18n 的 stats.period 和 gameStats.period 均添加 day/year 翻译